### PR TITLE
Fix Figura compatibility

### DIFF
--- a/compat/src/main/java/folk/sisby/switchy/client/SwitchyFiguraApi.java
+++ b/compat/src/main/java/folk/sisby/switchy/client/SwitchyFiguraApi.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @LuaWhitelist
 public class SwitchyFiguraApi implements FiguraAPI {
 	public static Map<Avatar, LuaFunction> AVATAR_LISTENERS = new HashMap<>();
-	public final @NotNull Avatar forAvatar;
+	public @NotNull Avatar forAvatar;
 
 	static {
 		SwitchyClientEvents.SWITCH.register((event) -> AVATAR_LISTENERS.forEach((avatar, function) -> function.invoke(
@@ -37,6 +37,8 @@ public class SwitchyFiguraApi implements FiguraAPI {
 			})
 		)));
 	}
+
+	public SwitchyFiguraApi() {}
 
 	private SwitchyFiguraApi(@NotNull Avatar avatar) {
 		forAvatar = avatar;

--- a/compat/src/main/java/folk/sisby/switchy/client/SwitchyFiguraApi.java
+++ b/compat/src/main/java/folk/sisby/switchy/client/SwitchyFiguraApi.java
@@ -28,14 +28,21 @@ public class SwitchyFiguraApi implements FiguraAPI {
 	public @NotNull Avatar forAvatar;
 
 	static {
-		SwitchyClientEvents.SWITCH.register((event) -> AVATAR_LISTENERS.forEach((avatar, function) -> function.invoke(
-			LuaValue.varargsOf(new LuaValue[]{
-				LuaValue.valueOf(event.player().toString()),
-				event.currentPreset() != null ? LuaValue.valueOf(event.currentPreset()) : LuaValue.NIL,
-				event.previousPreset() != null ? LuaValue.valueOf(event.previousPreset()) : LuaValue.NIL,
-				LuaValue.listOf(event.enabledModules().stream().map(LuaValue::valueOf).toArray(LuaValue[]::new))
-			})
-		)));
+		SwitchyClientEvents.SWITCH.register((event) -> AVATAR_LISTENERS.forEach((avatar, function) -> {
+			if (avatar.scriptError) return;
+			try {
+				function.invoke(
+					LuaValue.varargsOf(new LuaValue[]{
+						LuaValue.valueOf(event.player().toString()),
+						event.currentPreset() != null ? LuaValue.valueOf(event.currentPreset()) : LuaValue.NIL,
+						event.previousPreset() != null ? LuaValue.valueOf(event.previousPreset()) : LuaValue.NIL,
+						LuaValue.listOf(event.enabledModules().stream().map(LuaValue::valueOf).toArray(LuaValue[]::new))
+					})
+				);
+			} catch (LuaError e) {
+				avatar.luaRuntime.error(e);
+			}
+		}));
 	}
 
 	public SwitchyFiguraApi() {}


### PR DESCRIPTION
Fabric expects a public constructor with no parameters to be the entrypoint.

Figura will later use `build(Avatar)` to run the `private SwitchyFiguraApi(Avatar)` constructor.

From my quick testing this does not cause any issues.
Should fix #75
