### PR TITLE
Fix equipment not switching in MC 26.1 due to NBT format change

### DIFF
--- a/src/main/java/dev/sisby/switchy/data/SwitchyComponentType.java
+++ b/src/main/java/dev/sisby/switchy/data/SwitchyComponentType.java
@@ -230,7 +230,14 @@ public interface SwitchyComponentType<T> extends TypeRegistry.Type {
 				}
 				return result.resultOrPartial(Switchy.LOGGER::error).orElse(null);
 			} catch (CommandSyntaxException e) {
-				return null;
+				// The path is absent from the player NBT. Some vanilla data omits its key entirely when "empty"
+				// (e.g. MC 26.1 only writes "equipment" when the player has something equipped). Returning null here
+				// would make DispatchMapCodec drop the component when the profile is saved, so the profile would no
+				// longer carry an "empty" value to switch back to - leaving the previous profile's data in place.
+				// Instead, decode the codec's representation of an empty value (e.g. {} -> empty map) so the component
+				// survives serialization and gets written back, clearing the slot on switch. Codecs that can't parse
+				// an empty compound (scalars, lists) still fall back to null, preserving the old behaviour.
+				return codec.parse(registryManager.createSerializationContext(NbtOps.INSTANCE), new CompoundTag()).result().orElse(null);
 			}
 		}
 

--- a/src/main/java/dev/sisby/switchy/data/SwitchyComponentTypes.java
+++ b/src/main/java/dev/sisby/switchy/data/SwitchyComponentTypes.java
@@ -66,30 +66,33 @@ public class SwitchyComponentTypes extends TypeRegistry<SwitchyComponentType<?>>
 		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "text"), ComponentSerialization.CODEC),
 		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "vec3d"), Vec3.CODEC),
 		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "identifier"), Identifier.CODEC),
-		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "inventory"), SwitchyCodecs.INVENTORY_CODEC)
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "inventory"), SwitchyCodecs.INVENTORY_CODEC),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "equipment"), SwitchyCodecs.EQUIPMENT_CODEC)
 	));
-	public static final Map<Identifier, SwitchyComponentType.TextProvider<?>> TEXT_PROVIDERS = new HashMap<>(Map.of(
-		Identifier.fromNamespaceAndPath("minecraft", "trunc"), new SwitchyComponentType.SimpleTextProvider<>(FormatUtils::truncate),
-		Identifier.fromNamespaceAndPath("minecraft", "nbt"), new SwitchyComponentType.SimpleTextProvider<net.minecraft.nbt.Tag>(e -> FormatUtils.nbtPathResultText(List.of(e), true)),
-		Identifier.fromNamespaceAndPath("minecraft", "text"), new SwitchyComponentType.SimpleTextProvider<Component>(t -> t),
-		Identifier.fromNamespaceAndPath("minecraft", "percent"), new SwitchyComponentType.SimpleTextProvider<Number>(n -> Component.nullToEmpty("%.0f%%".formatted(n.floatValue() * 100.0))),
-		Identifier.fromNamespaceAndPath("minecraft", "rounded"), new SwitchyComponentType.SimpleTextProvider<Number>(n -> Component.nullToEmpty("%.0f".formatted(n.floatValue()))),
-		Identifier.fromNamespaceAndPath("minecraft", "halves"), new SwitchyComponentType.SimpleTextProvider<>(FormatUtils::statText),
-		Identifier.fromNamespaceAndPath("minecraft", "vec3d"), new SwitchyComponentType.SimpleTextProvider<Vec3>(c -> ComponentUtils.formatList(List.of(
+	public static final Map<Identifier, SwitchyComponentType.TextProvider<?>> TEXT_PROVIDERS = new HashMap<>(Map.ofEntries(
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "trunc"), new SwitchyComponentType.SimpleTextProvider<>(FormatUtils::truncate)),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "nbt"), new SwitchyComponentType.SimpleTextProvider<net.minecraft.nbt.Tag>(e -> FormatUtils.nbtPathResultText(List.of(e), true))),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "text"), new SwitchyComponentType.SimpleTextProvider<Component>(t -> t)),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "percent"), new SwitchyComponentType.SimpleTextProvider<Number>(n -> Component.nullToEmpty("%.0f%%".formatted(n.floatValue() * 100.0)))),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "rounded"), new SwitchyComponentType.SimpleTextProvider<Number>(n -> Component.nullToEmpty("%.0f".formatted(n.floatValue())))),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "halves"), new SwitchyComponentType.SimpleTextProvider<>(FormatUtils::statText)),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "vec3d"), new SwitchyComponentType.SimpleTextProvider<Vec3>(c -> ComponentUtils.formatList(List.of(
 			Component.empty().append(Component.literal("X:").withStyle(ChatFormatting.GRAY)).append(Component.literal(String.valueOf(BlockPos.containing(c).getX()))),
 			Component.empty().append(Component.literal("Y:").withStyle(ChatFormatting.GRAY)).append(Component.literal(String.valueOf(BlockPos.containing(c).getY()))),
 			Component.empty().append(Component.literal("Z:").withStyle(ChatFormatting.GRAY)).append(Component.literal(String.valueOf(BlockPos.containing(c).getZ())))
-		), Component.literal(", ").withStyle(ChatFormatting.GRAY))),
-		Identifier.fromNamespaceAndPath("minecraft", "identifier"), new SwitchyComponentType.SimpleTextProvider<Identifier>(i -> Component.nullToEmpty(FormatUtils.prettify(i.getPath()))),
-		Identifier.fromNamespaceAndPath("minecraft", "inventory"), new SwitchyComponentType.SimpleTextProvider<>(FormatUtils::inventoryText),
-		Identifier.fromNamespaceAndPath("minecraft", "skin"), new SwitchyComponentType.SimpleServerTextProvider<>(FormatUtils::skin)
+		), Component.literal(", ").withStyle(ChatFormatting.GRAY)))),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "identifier"), new SwitchyComponentType.SimpleTextProvider<Identifier>(i -> Component.nullToEmpty(FormatUtils.prettify(i.getPath())))),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "inventory"), new SwitchyComponentType.SimpleTextProvider<>(FormatUtils::inventoryText)),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "skin"), new SwitchyComponentType.SimpleServerTextProvider<>(FormatUtils::skin)),
+		Map.entry(Identifier.fromNamespaceAndPath("minecraft", "equipment"), new SwitchyComponentType.SimpleTextProvider<>(FormatUtils::equipmentText))
 	));
 
 	public static final Map<Identifier, SwitchyComponentType.ArgumentEditor<?>> ARGUMENT_EDITORS = new HashMap<>(Map.of(
 		Identifier.fromNamespaceAndPath("minecraft", "text"), new SwitchyComponentType.SimpleArgumentEditor<Component>(e -> Commands.argument("name", StringArgumentType.greedyString()).executes(c -> e.execute(c, Component.nullToEmpty(c.getArgument("name", String.class)))))
 	));
 	public static final Map<Identifier, SwitchyComponentType.EmptyChecker<?>> EMPTY_CHECKERS = new HashMap<>(Map.of(
-		Identifier.fromNamespaceAndPath("minecraft", "inventory"), new SwitchyComponentType.SimpleEmptyChecker<NonNullList<ItemStack>>(dl -> dl.stream().allMatch(ItemStack::isEmpty))
+		Identifier.fromNamespaceAndPath("minecraft", "inventory"), new SwitchyComponentType.SimpleEmptyChecker<NonNullList<ItemStack>>(dl -> dl.stream().allMatch(ItemStack::isEmpty)),
+		Identifier.fromNamespaceAndPath("minecraft", "equipment"), new SwitchyComponentType.SimpleEmptyChecker<Map<String, ItemStack>>(m -> m == null || m.isEmpty() || m.values().stream().allMatch(ItemStack::isEmpty))
 	));
 	public static final Map<Identifier, SwitchyComponentType.Initializer<?>> INITIALIZERS = new HashMap<>(Map.of(
 		Identifier.fromNamespaceAndPath("minecraft", "spawn_pos"), (nbt, player, id) -> ((AccessServerPlayer) player).getServer().overworld().getRespawnData().pos().getCenter()
@@ -116,6 +119,7 @@ public class SwitchyComponentTypes extends TypeRegistry<SwitchyComponentType<?>>
 	public static final Identifier LEVEL = Identifier.fromNamespaceAndPath("minecraft", "xp/level");
 	public static final Identifier INVENTORY = Identifier.fromNamespaceAndPath("minecraft", "inventory/inventory");
 	public static final Identifier ENDER_CHEST = Identifier.fromNamespaceAndPath("minecraft", "inventory/ender_chest");
+	public static final Identifier EQUIPMENT = Identifier.fromNamespaceAndPath("minecraft", "inventory/equipment");
 	public static final Identifier ORIGINS_ORIGIN = Identifier.fromNamespaceAndPath("origins", "origin");
 	public static final Identifier ORIGINS_POWERS = Identifier.fromNamespaceAndPath("origins", "powers");
 	public static final Identifier TAILOR_SKIN = Identifier.fromNamespaceAndPath("fabrictailor", "skin");

--- a/src/main/java/dev/sisby/switchy/util/FormatUtils.java
+++ b/src/main/java/dev/sisby/switchy/util/FormatUtils.java
@@ -30,8 +30,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
 
 import java.text.NumberFormat;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -57,6 +59,28 @@ public class FormatUtils {
 			.withStyle(s -> s.withHoverEvent(new HoverEvent.ShowText(Component.empty().append(Component.literal("Contents:\n").withStyle(ChatFormatting.GRAY)).append(ComponentUtils.formatList(inventory.stream().filter(i -> !i.isEmpty()).map(i -> Component.empty().append(Component.literal("- ").withStyle(ChatFormatting.GRAY)).append(String.valueOf(i.getCount())).append("x ").append(i.getHoverName())).toList(), Component.nullToEmpty("\n"))))))
 			.append(String.valueOf(inventory.stream().filter(i -> !i.isEmpty()).count()))
 			.append(Component.literal(" stacks").withStyle(ChatFormatting.GRAY));
+	}
+
+	public static Component equipmentText(Map<String, ItemStack> equipment) {
+		List<Map.Entry<String, ItemStack>> items = equipment == null
+			? Collections.emptyList()
+			: equipment.entrySet().stream().filter(e -> !e.getValue().isEmpty()).toList();
+		if (items.isEmpty())
+			return Component.literal("(nothing equipped)").withStyle(ChatFormatting.GRAY);
+		return Component.empty()
+			.withStyle(s -> s.withHoverEvent(new HoverEvent.ShowText(
+				Component.empty()
+					.append(Component.literal("Equipment:\n").withStyle(ChatFormatting.GRAY))
+					.append(ComponentUtils.formatList(
+						items.stream()
+							.map(e -> Component.empty()
+								.append(Component.literal("- " + prettify(e.getKey()) + ": ").withStyle(ChatFormatting.GRAY))
+								.append(e.getValue().getCount() > 1 ? Component.literal(e.getValue().getCount() + "x ").withStyle(ChatFormatting.GRAY) : Component.empty())
+								.append(e.getValue().getHoverName()))
+							.toList(),
+						Component.literal("\n"))))))
+			.append(String.valueOf(items.size()))
+			.append(Component.literal(" slots").withStyle(ChatFormatting.GRAY));
 	}
 
 	public static Component nbtPathResultText(List<Tag> results, boolean allowHover) {

--- a/src/main/java/dev/sisby/switchy/util/SwitchyCodecs.java
+++ b/src/main/java/dev/sisby/switchy/util/SwitchyCodecs.java
@@ -17,6 +17,7 @@ import net.minecraft.util.ExtraCodecs;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public interface SwitchyCodecs {
 	PrimitiveCodec<Byte> BYTE = new PrimitiveCodec<>() {
@@ -56,6 +57,11 @@ public interface SwitchyCodecs {
 		}
 		return l;
 	});
+
+	Codec<Map<String, ItemStack>> EQUIPMENT_CODEC = Codec.unboundedMap(
+		Codec.STRING,
+		ITEM_STACK_MAP_CODEC.codec()
+	);
 
 	record StackWithSlot(int slot, ItemStack stack) {
 		public static final Codec<StackWithSlot> CODEC = RecordCodecBuilder.create(

--- a/src/main/resources/data/minecraft/switchy_components/inventory/equipment.json
+++ b/src/main/resources/data/minecraft/switchy_components/inventory/equipment.json
@@ -1,0 +1,10 @@
+{
+	"enabled": true,
+	"codec": "equipment",
+	"path": "equipment",
+	"preview": "equipment",
+	"priority": 90,
+	"emptyChecker": "equipment",
+	"group": "inventory",
+	"default": {}
+}


### PR DESCRIPTION
Minecraft 25w06a (before 1.21.5) moved armor/offhand out of the Inventory array (slot indices 100-103 and -106) into a new `equipment` compound tag. This change adds a new `equipment` component type with an unbounded-map codec that handles the {slotName -> ItemStack} compound format.

I have tested this with a Fabric server on 26.1.2.

This fixes #164